### PR TITLE
Fixed a bug in generateAssetName

### DIFF
--- a/src/Assetic/Factory/AssetFactory.php
+++ b/src/Assetic/Factory/AssetFactory.php
@@ -28,8 +28,8 @@ class AssetFactory extends \Assetic\Factory\AssetFactory
         $partPaths = pathinfo($path);
 
         $name = str_replace($options['root'], '', $path);
-        $name = str_replace($partPaths['basename'], '', $name);
+        $name = dirname($name);
 
-        return ltrim($name . $partPaths['filename'], '/');
+        return ltrim("{$name}/{$partPaths['filename']}", '/');
     }
 }

--- a/tests/Assetic/Factory/AssetFactoryTest.php
+++ b/tests/Assetic/Factory/AssetFactoryTest.php
@@ -29,4 +29,16 @@ class AssetFactoryTest extends \PHPUnit_Framework_TestCase
             $assetFactory->generateAssetName(array(__FILE__), array(), array('root' => $root))
         );
     }
+
+    public function testGenerateAssetNameWithAssetNameEqualsToFolderName()
+    {
+        $root = realpath(__DIR__ . DIRECTORY_SEPARATOR . '..');
+
+        $assetFactory = new AssetFactory($root);
+
+        $this->assertEquals(
+            'some_dir/normalize.css/normalize',
+            $assetFactory->generateAssetName(array("/some_dir/normalize.css/normalize.css"), array(), array('root' => $root))
+        );
+    }
 }


### PR DESCRIPTION
Fixed **generateAssetName** method to handle paths correctly when one of the parent directories' name equals to the name of the asset.

For example, for **some_dir/normalize.css/normalize.css**, the generated name was **some_dir//normalize** which is obviously incorrect.
